### PR TITLE
Update nonbreaking_prefix.sv

### DIFF
--- a/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.sv
+++ b/scripts/share/nonbreaking_prefixes/nonbreaking_prefix.sv
@@ -25,22 +25,73 @@ W
 X
 Y
 Z
+Å
+Ä
+Ö  
 #misc abbreviations
+#If all words in text are in small case, then tex, mao, tom, maj, may be confused with names, and iaf, etc with named entities.
 AB
-G
 VG
 dvs
+d.v.s
+d. v. s
 etc
 from
+fr.o.m
+fr. o. m
 iaf
+i.a.f
+i. a. f
 jfr
 kl
 kr
 mao
+m.a.o
+m. a. o
 mfl
+m.fl
+m. fl
 mm
+m.m
+m. m.
 osv
+o.s.v
+o. s. v
 pga
+p.g.a
+p. g. a
 tex
+t.ex
+t. ex
+#tom. is risky, as tom is a word, and can be at end of sentence. One recent text has 9 tom., and 52 tom not at end of sentence. 
 tom
+t.o.m
+t. o. m
 vs
+adv
+jur
+kand
+mag
+fil
+lic
+prop
+d
+f
+s
+mha
+m.h.a
+m. h. a
+vol
+#months
+jan
+feb
+mar
+apr
+#maj is a full word
+jun
+jul
+aug
+sep
+okt
+nov
+dec


### PR DESCRIPTION
Added Å Ä Ö, which are not unusual initials in names, e.g. Åke, Ärling, Östen.
Added some new, but mostly variations on the existing ones. Both a dot after each letter (or pair) and a dot only after last letter are accepted forms. A couple of decades ago, there had to be a space after the dot, which explains the third form.
The file for sv is much more useful with these few additions. Although, It is still far from complete.
Removed: G (occured twice).
In this list there is one item that is also a word, even when case is kept: tom.
If all words are in small case, then tex, mao, tom (again), may be confused with names, and iaf, etc with named entities.